### PR TITLE
Use query selector

### DIFF
--- a/final_crawler.py
+++ b/final_crawler.py
@@ -100,13 +100,11 @@ for j in range(len(link)):
             print('No review, Pass')
             break
         else:
-            items = soup.findAll("span",{'data-hook':"review-body"})
+            items = soup.select('span[data-hook="review-body"] > span')
             print(f"{len(items)} reviews found")
             for i in items:
-                for child in i.children:
-                    if child.string:
-                        reviews.append(child.string)
-                        search_query_list.append(SEARCH_QUERY)
+                reviews.append(i.text)
+                search_query_list.append(SEARCH_QUERY)
 
 print(f"Finished: {len(reviews)} reviews found")
 


### PR DESCRIPTION
Resolve #3 

- children에 span 뿐만 아니라 :before, :after pseudo element도 포함되는 문제를 해결하였습니다.
- 정확한 원인은 모르겠으나 첫번째 리뷰가 누락되는 현상이 해결되었습니다.